### PR TITLE
Improve IsDotNetSdkProject method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # User-specific files
-/Properties/launchSettings.json
+**/Properties/launchSettings.json
 
 # Build results
 build/

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -139,7 +139,10 @@ static bool IsDotNetSdkProject(string projectPath)
         return false;
 
     var project = ProjectRootElement.Open(projectPath);
-    return !string.IsNullOrEmpty(project.Sdk);
+
+    // If Sdk property is set, then the .csproj is in the new format. But it can also import the Sdk.
+    // If the DefaultTargets="Build" then it is typical an old format.
+    return !string.IsNullOrEmpty(project!.Sdk) || string.IsNullOrEmpty(project.DefaultTargets);
 }
 
 static void DisplayErrorMessage(string format, params object[] arguments)


### PR DESCRIPTION
Some .csproj file have an empty Sdk property, but
are using an import statement to include the required Sdk files. Use DefaultTargets not empty to detect an old format.